### PR TITLE
Adapted the no-libdb.patch to new meson build options

### DIFF
--- a/patches/no-libdb.patch
+++ b/patches/no-libdb.patch
@@ -1,26 +1,26 @@
-diff --color -Naur a/debian/control b/debian/control
---- a/debian/control	2024-05-07 12:18:59.206573936 +0200
-+++ b/debian/control	2024-05-07 12:20:54.986837743 +0200
-@@ -4,9 +4,9 @@
+diff --color -Nuar a/debian/control b/debian/control
+--- a/debian/control	2025-01-30 02:58:07.000000000 +0100
++++ b/debian/control	2025-02-05 11:23:28.503204141 +0100
+@@ -3,9 +3,9 @@
+ Priority: optional
  Maintainer: Sam Hartman <hartmans@debian.org>
- Uploaders: Steve Langasek <vorlon@debian.org>
  Standards-Version: 4.6.2
--Build-Depends: debhelper-compat (= 13), dh-exec,  flex,  libcrypt-dev, libdb-dev, libselinux1-dev [linux-any], libsystemd-dev [linux-any] <!stage1>, po-debconf, autopoint, libaudit-dev [linux-any] <!stage1>, pkg-config, libfl-dev, libfl-dev:native, docbook-xsl-ns, docbook5-xml, xsltproc, libxml2-utils, w3m
-+Build-Depends: debhelper-compat (= 13), dh-exec,  flex,  libcrypt-dev, libselinux1-dev [linux-any], libsystemd-dev [linux-any] <!stage1>, po-debconf, autopoint, libaudit-dev [linux-any] <!stage1>, pkg-config, libfl-dev, libfl-dev:native, docbook-xsl-ns, docbook5-xml, xsltproc, libxml2-utils, w3m
- Build-Conflicts-Indep: fop
+-Build-Depends: debhelper-compat (= 13), dh-exec,  flex,  libcrypt-dev, libdb-dev, libselinux1-dev [linux-any], libsystemd-dev [linux-any] <!stage1>, po-debconf, meson, libaudit-dev [linux-any] <!stage1>, pkgconf, libfl-dev, libfl-dev:native
++Build-Depends: debhelper-compat (= 13), dh-exec,  flex,  libcrypt-dev, libgdbm-dev, libselinux1-dev [linux-any], libsystemd-dev [linux-any] <!stage1>, po-debconf, meson, libaudit-dev [linux-any] <!stage1>, pkgconf, libfl-dev, libfl-dev:native
+ Build-Depends-Indep: docbook-xsl-ns, docbook5-xml, xsltproc, libxml2-utils, w3m, fop
 -Build-Conflicts: libdb4.2-dev, libxcrypt-dev
 +Build-Conflicts: libxcrypt-dev
  Vcs-Browser: https://salsa.debian.org/vorlon/pam
  Vcs-Git: https://salsa.debian.org/vorlon/pam.git
  Homepage: http://www.linux-pam.org/
-diff --color -Naur a/debian/rules b/debian/rules
---- a/debian/rules	2024-05-07 12:18:59.210573944 +0200
-+++ b/debian/rules	2024-05-07 12:21:14.738877680 +0200
-@@ -36,6 +36,7 @@
- 		--enable-isadir=/usr/lib/security \
- 		--with-systemdunitdir=/usr/lib/systemd/system \
- 		--disable-nis \
-+		--disable-db \
- 		--enable-usergroups \
- 		$(CONFIGURE_OPTS)
+diff --color -Nuar a/debian/rules b/debian/rules
+--- a/debian/rules	2025-01-30 02:58:07.000000000 +0100
++++ b/debian/rules	2025-02-05 11:53:07.513207831 +0100
+@@ -41,6 +41,7 @@
+		-Disadir=/usr/lib/security \
+		-Dsystemdunitdir=/usr/lib/systemd/system \
+		-Dnis=disabled \
++		-Ddb=gdbm \
+		-Dusergroups=true \
+		$(meson_OPTS)
  


### PR DESCRIPTION
libdb is now not used but libgdbm instead

meson build options differ from the previous syntax

**What this PR does / why we need it**:
The build options / build system for the debian package changed. The meson build options can be seen here:

https://github.com/linux-pam/linux-pam/blob/ea980d991196df67cdd56b3f65d210b73218d08a/meson_options.txt#L91

libdb is not used but libgdbm instead.

**Which issue(s) this PR fixes**:
Fixes #[2652](https://github.com/gardenlinux/gardenlinux/issues/2652)

**Special notes for your reviewer**:
While the file .buildinfo still mentions libdb according to 
https://manpages.debian.org/testing/dpkg-dev/deb-buildinfo.5.en.html#Installed-Build-Depends:

The list of installed and configured packages that might affect the package build process. 

and we did not find a way to completely remove said package / library from the build container / build environment. The resulting binaries do not use libdb nor are they linked against libdb.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
